### PR TITLE
Update hostname

### DIFF
--- a/webapps/sciviz/utah_organoids_specsheet.yaml
+++ b/webapps/sciviz/utah_organoids_specsheet.yaml
@@ -3,7 +3,7 @@ LabBook: null
 SciViz: # top level tab
   auth:
     mode: "database"
-  hostname: "tutorial-db.datajoint.io"
+  hostname: "rds.datajoint.io"
   pages: # individual pages
     Home:
       route: /home


### PR DESCRIPTION
The host names `tutorial-db.datajoint.io` and `rds.datajoint.io` are aliases, so updating to the more appropriate name.