### PR TITLE
chore: temporarily disable MUA analysis in worker manager

### DIFF
--- a/src/workflow/populate/worker.py
+++ b/src/workflow/populate/worker.py
@@ -43,9 +43,9 @@ spike_sorting_worker = DataJointWorker(
 # -------- Define flow(s) --------
 
 # mua
-standard_worker(mua.MUAEphysSession, max_calls=20)
-standard_worker(mua.MUASpikes, max_calls=20)
-standard_worker(mua.MUATracePlot, max_calls=20)
+# standard_worker(mua.MUAEphysSession, max_calls=20)
+# standard_worker(mua.MUASpikes, max_calls=20)
+# standard_worker(mua.MUATracePlot, max_calls=20)
 
 # ephys LFP
 standard_worker(ingestion_support.FileProcessing)


### PR DESCRIPTION
Temporarily disable the automatic MUA analysis on all files until the team decides how to proceed.