### PR TITLE
fix(mua): add `unsigned_to_signed` to `_get_si_recording` for  SI 0.103+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## `V0.18.1`
+
+### Features
+
+- fix: add `unsigned_to_signed` to `_build_si_recording_object` for new version of SI 0.103+
+
 ## `V0.18.0`
 
 ### Features

--- a/src/workflow/pipeline/mua.py
+++ b/src/workflow/pipeline/mua.py
@@ -355,6 +355,12 @@ def _get_si_recording(start_time, end_time, parent_folder, port_id):
     si_recording = si_recording.select_channels(
         si_recording.channel_ids[port_indices]
     )  # select only the port data
+
+    # Check if recording is unsigned and convert if necessary
+    # Please check the SI documentation for more details: https://spikeinterface.readthedocs.io/en/latest/how_to/unsigned_to_signed.html
+    if str(si_recording.get_dtype()).startswith("u"):
+        si_recording = si.preprocessing.unsigned_to_signed(si_recording)
+
     return si_recording
 
 

--- a/src/workflow/version.py
+++ b/src/workflow/version.py
@@ -1,3 +1,3 @@
 """Package metadata"""
 
-__version__ = "0.18.0"
+__version__ = "0.18.1"


### PR DESCRIPTION
This PR intends to solve issue #172 following SpikeInterface documentation: 

"As of version 0.103.0 SpikeInterface has changed one of its defaults for interacting with Recording objects. **We no longer autocast unsigned dtypes to signed implicitly.** This means that some users of SpikeInterface will need to add one **additional line of code** to their scripts to explicitly handle this conversion.

If you are curious if your Recording is unsigned you can simply check the repr or use get_dtype():
print(recording.get_dtype())
In either case, **if the dtype displayed has a u at the beginning** (e.g. uint16) then your recording is unsigned. If it doesn’t have the u (e.g. int16) then it is signed and would not need this preprocessing step.`
Reference: https://spikeinterface.readthedocs.io/en/latest/how_to/unsigned_to_signed.html 