### PR TITLE
chore(MUATracePlot): temporarily limited `key_source` for testing/validation

### DIFF
--- a/src/workflow/pipeline/mua.py
+++ b/src/workflow/pipeline/mua.py
@@ -216,7 +216,7 @@ class MUATracePlot(dj.Computed):
         waveform_plot: attach
         """
 
-    spike_rate_threshold = 0.5
+    spike_rate_threshold = 100.0  # Hz, temporarily set high for testing/validation (default was 0.5 Hz)
 
     key_source = (
         MUASpikes


### PR DESCRIPTION
Hi @ttngu207 @judewerth,

Jude and I discussed the new pipeline extension proposed in #196 to combine LFP and MUA data and manage large data volumes in blocks of sessions for coherence analysis.

The next key step we agree on is to manually insert a 1-hour block of `MUAEphysSession` data so we can verify that the processing time for `MUASpikes` and the relevant metrics in `Channel` are feasible. We do not need to process the `MUATracePlot` data at this point, as it is the bottleneck in the pipeline regarding resources and time.

(1) In this PR, I modify the `MUATracePlot` `key_source` to limit plot generation, since that appears to be the current bottleneck for block analysis and data processing and storage. Once this PR is merged, I will rebuild the standard worker.

(2) After completing that step, I will inform Jude so he can manually insert the 1-hour block into `MUAEphysSession` (since this table is to be included in the worker flow to prevent analyzing all current data).

(3) We will review this together before moving on to larger block sizes, as it is critical not to overload the system with many jobs that could impact performance.

(4) If we agree that processing the 1-hour test is time-efficient, we can then consider running a full day of data for `MUASpikes` analysis to assess how the pipeline performs with larger datasets.

Based on these performance tests, we will decide how best to structure the new pipeline extension outlined in #196. 