### PR TITLE
fix: Pin datajoint version to <2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
 ]
 dependencies = [
-    "datajoint @ git+https://github.com/datajoint/datajoint-python.git",
+    "datajoint>=0.14,<2.0",
     "datajoint-utilities @ git+https://github.com/datajoint-company/datajoint-utilities.git",
     "djsciops",
     "docker",


### PR DESCRIPTION
## Summary
- Pin datajoint dependency to `>=0.14,<2.0` to prevent installation of DJ 2.0

## Problem
The worker AMI build was failing with:
```
KeyError: "Setting 'custom' not found"
```

This is because `datajoint @ git+https://github.com/datajoint/datajoint-python.git` now installs DJ 2.0 from main branch, which has breaking changes (e.g., `dj.config["custom"]` is no longer supported).

## Solution
Pin datajoint to `<2.0` until a proper migration to DJ 2.0 is planned.

## Test plan
- [ ] Trigger worker AMI build and verify it completes without the KeyError

🤖 Generated with [Claude Code](https://claude.com/claude-code)