### PR TITLE
refactor: redesign OrganoidImplantationImage to reference Experiment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## `V0.19.0`
+
+### Features
+
+- refactor: redesign `OrganoidImplantationImage` to reference `Experiment` instead of `OrganoidCulture`, matching the per-organoid image data structure
+
+### Migration Notes
+
+- The old `OrganoidImplantationImage` table (under `OrganoidCulture`) must be dropped before activating this version
+- Images are inserted at the Control experiment level for each organoid
+
 ## `V0.18.1`
 
 ### Features

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "utah_organoids"
-version = "0.17.0"
+version = "0.19.0"
 description = "Organoids electrophysiology pipeline using the DataJoint elements"
 readme = "README.md"
 requires-python = "==3.10.*"

--- a/src/workflow/pipeline/culture.py
+++ b/src/workflow/pipeline/culture.py
@@ -147,15 +147,6 @@ class OrganoidCulture(dj.Manual):
 
 
 @schema
-class OrganoidImplantationImage(dj.Manual):
-    definition = """
-    -> OrganoidCulture
-    ---
-    organoid_implantation_image: attach  # Organoid implantation image (TIF file)
-    """
-
-
-@schema
 class OrganoidCultureCondition(dj.Manual):
     definition = """
     -> OrganoidCulture
@@ -199,6 +190,15 @@ class Experiment(dj.Manual):
     -> [nullable] Drug
     drug_concentration=null     : float # concentration in uM
     experiment_plan             : varchar(64) # e.g. mrna lysate, oct, protein lysate, or matrigel embedding, ephys, tracing
+    """
+
+
+@schema
+class OrganoidImplantationImage(dj.Manual):
+    definition = """
+    -> Experiment  # Use the Control experiment entry for each organoid
+    ---
+    organoid_implantation_image: attach
     """
 
 

--- a/src/workflow/version.py
+++ b/src/workflow/version.py
@@ -1,3 +1,3 @@
 """Package metadata"""
 
-__version__ = "0.18.1"
+__version__ = "0.19.0"


### PR DESCRIPTION
## Summary
- Redesign `OrganoidImplantationImage` to reference `Experiment` instead of `OrganoidCulture`
- Images are per-organoid (mapped by `organoid_id`), not per-culture lineage chain
- Insert at the Control experiment level for each organoid
- Bump version to `0.19.0`

## Migration Notes
- The old `OrganoidImplantationImage` table (referencing `OrganoidCulture`) must be dropped before activating this version
- The single existing entry (hmau001) was a test and can be safely removed

## Test plan
- [ ] Drop old `OrganoidImplantationImage` table
- [ ] Activate updated schema and verify new table is created
- [ ] Insert implantation images for all organoids using Control experiment keys
- [ ] Verify images display correctly in the dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)